### PR TITLE
Amend docker-compose files to work with hosts nginx-proxy

### DIFF
--- a/docker-compose-api.yml
+++ b/docker-compose-api.yml
@@ -2,13 +2,13 @@ version: '2'
 services:
   api:
     image: ${REGISTRY_URL}/stockportcontentapi:${TAG}
+    container_name: content
     ports:
       - 8080:5001
     environment:
       - http_proxy
       - https_proxy
       - no_proxy
-      - VIRTUAL_HOST=*.dbdtest.stockport.gov.uk,content
       - HEALTHY_STOCKPORT_ACCESS_KEY
       - HEALTHY_STOCKPORT_SPACE
       - STOCKPORT_GOV_ACCESS_KEY

--- a/docker-compose-webapp.yml
+++ b/docker-compose-webapp.yml
@@ -3,7 +3,7 @@ services:
   web:
     image: ${REGISTRY_URL}/stockportwebapp:${TAG}
     environment:
-      - VIRTUAL_HOST=*.healthystockport.co.uk
+      - VIRTUAL_HOST
       - BUSINESS_ID
       - AUTH_PASSWORD
     links:

--- a/docker-compose-webapp.yml
+++ b/docker-compose-webapp.yml
@@ -2,11 +2,9 @@ version: '2'
 services:
   web:
     image: ${REGISTRY_URL}/stockportwebapp:${TAG}
-    ports:
-      - 80:5000
     environment:
-      - VIRTUAL_HOST=*.dbdtest.stockport.gov.uk,content
+      - VIRTUAL_HOST=*.healthystockport.co.uk
       - BUSINESS_ID
       - AUTH_PASSWORD
-    external_links:
-      - app_api_1:content
+    links:
+      - content


### PR DESCRIPTION
Please merge to allow using an nginx-proxy on Docker hosts to present different web apps based on port 80 based on VHOST.

This needs doing to support stockport.gov.uk / healthystockport.co.uk and DTS apps. 