### PR TITLE
Fix external_links

### DIFF
--- a/docker-compose-webapp.yml
+++ b/docker-compose-webapp.yml
@@ -6,5 +6,5 @@ services:
       - VIRTUAL_HOST
       - BUSINESS_ID
       - AUTH_PASSWORD
-    links:
+    external_links:
       - content


### PR DESCRIPTION
links to containers not managed by current docker-compose file need referencing as external_links